### PR TITLE
Degree-255 Polynomial (de)Serialization

### DIFF
--- a/include/serialize.hpp
+++ b/include/serialize.hpp
@@ -5,6 +5,22 @@
 // IND-CPA-secure Public Key Encryption Scheme
 namespace indcpa {
 
+// Compile-time check to ensure that at max 12 -bits ( from LSB side ) of
+// polynomial coefficients are considered to be significant during
+//
+// - serialization to byte array
+// - deserialization to degree-255 polynomial
+//
+// Note, bit-width of Kyber prime ( = 3329 ) is 12
+//
+// $ python3
+// >>> (3329).bit_length()
+static constexpr bool
+check_l(const size_t l)
+{
+  return l <= 12;
+}
+
 // Given a degree-255 polynomial, where significant portion of each ( total 256
 // of them ) coefficient ∈ [0, 2^l), this routine serializes the polynomial to a
 // byte array of length 32 * l -bytes
@@ -16,7 +32,7 @@ template<const size_t l>
 static void
 encode(const ff::ff_t* const __restrict poly, // degree 255 polynomial
        uint8_t* const __restrict arr // byte array of length 32*l -bytes
-)
+       ) requires(check_l(l))
 {
   constexpr size_t len = 32 * l;
   constexpr size_t blen = len << 3;
@@ -32,6 +48,37 @@ encode(const ff::ff_t* const __restrict poly, // degree 255 polynomial
 
     const uint8_t bit = static_cast<uint8_t>((poly[pidx].v >> poff) & 0b1);
     arr[aidx] = a[aidx] ^ (bit << aoff);
+  }
+}
+
+// Given a byte array of length 32 * l -bytes this routine deserializes it to a
+// polynomial of degree 255 s.t. significant portion of each ( total 256 of them
+// ) coefficient ∈ [0, 2^l)
+//
+// See algorithm 3 described in section 1.1 ( page 7 ) of Kyber specification,
+// as submitted to NIST PQC final round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip
+template<const size_t l>
+static void
+decode(const uint8_t* const __restrict arr, // byte array of length 32*l -bytes
+       ff::ff_t* const __restrict poly      // degree 255 polynomial
+       ) requires(check_l(l))
+{
+  constexpr size_t n = 256;
+  constexpr size_t len = 32 * l;
+  constexpr size_t blen = len << 3;
+
+  std::memset(poly, 0, n * sizeof(ff::ff_t));
+
+  for (size_t i = 0; i < blen; i++) {
+    const size_t aidx = i >> 3;
+    const size_t aoff = i & 7ul;
+
+    const size_t pidx = i / l;
+    const size_t poff = i % l;
+
+    const uint8_t bit = (arr[aidx] >> aoff) & 0b1;
+    poly[pidx].v = poly[pidx].v ^ static_cast<uint16_t>(bit << poff);
   }
 }
 

--- a/include/serialize.hpp
+++ b/include/serialize.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "ff.hpp"
+#include <cstring>
+
+// IND-CPA-secure Public Key Encryption Scheme
+namespace indcpa {
+
+// Given a degree-255 polynomial, where significant portion of each ( total 256
+// of them ) coefficient ∈ [0, 2^l), this routine serializes the polynomial to a
+// byte array of length 32 * l -bytes
+//
+// See algorithm 3 described in section 1.1 ( page 7 ) of Kyber specification,
+// as submitted to NIST PQC final round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip
+template<const size_t l>
+static void
+encode(const ff::ff_t* const __restrict poly, // degree 255 polynomial
+       uint8_t* const __restrict arr // byte array of length 32*l -bytes
+)
+{
+  constexpr size_t len = 32 * l;
+  constexpr size_t blen = len << 3;
+
+  std::memset(arr, 0, len);
+
+  for (size_t i = 0; i < blen; i++) {
+    const size_t pidx = i / l;
+    const size_t poff = i % l;
+
+    const size_t aidx = i >> 3;
+    const size_t aoff = i & 7ul;
+
+    const uint8_t bit = static_cast<uint8_t>((poly[pidx].v >> poff) & 0b1);
+    arr[aidx] = a[aidx] ^ (bit << aoff);
+  }
+}
+
+}

--- a/include/serialize.hpp
+++ b/include/serialize.hpp
@@ -5,8 +5,8 @@
 // IND-CPA-secure Public Key Encryption Scheme
 namespace indcpa {
 
-// Compile-time check to ensure that at max 12 -bits ( from LSB side ) of
-// polynomial coefficients are considered to be significant during
+// Compile-time check to ensure that at min 1 -bit and at max 12 -bits ( from
+// LSB side ) of polynomial coefficients are considered to be significant during
 //
 // - serialization to byte array
 // - deserialization to degree-255 polynomial
@@ -18,7 +18,7 @@ namespace indcpa {
 static constexpr bool
 check_l(const size_t l)
 {
-  return l <= 12;
+  return (l > 0) && (l <= 12);
 }
 
 // Given a degree-255 polynomial, where significant portion of each ( total 256
@@ -47,7 +47,7 @@ encode(const ff::ff_t* const __restrict poly, // degree 255 polynomial
     const size_t aoff = i & 7ul;
 
     const uint8_t bit = static_cast<uint8_t>((poly[pidx].v >> poff) & 0b1);
-    arr[aidx] = a[aidx] ^ (bit << aoff);
+    arr[aidx] = arr[aidx] ^ (bit << aoff);
   }
 }
 

--- a/include/test_kyber.hpp
+++ b/include/test_kyber.hpp
@@ -1,3 +1,4 @@
 #pragma once
 #include "test_ff.hpp"
 #include "test_ntt.hpp"
+#include "test_serialize.hpp"

--- a/include/test_serialize.hpp
+++ b/include/test_serialize.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include "serialize.hpp"
+#include <cassert>
+
+// Test functional correctness of Kyber PQC suite implementation
+namespace test_kyber {
+
+// Ensure that degree-255 polynomial serialization to byte array ( of length
+// 32*l -bytes ) and deserialization of that byte array to degree-255 polynomial
+// works as expected for parameterizable values of l | l ∈ [1, 12]
+//
+// l denotes significant bit width ( from LSB side ) for each coefficient of
+// polynomial.
+template<const size_t l>
+static void
+test_serialization()
+{
+  constexpr size_t plen = sizeof(ff::ff_t) * ntt::N;
+  constexpr size_t blen = 32 * l;
+  constexpr uint16_t mask = (1u << l) - 1u;
+
+  ff::ff_t* src = static_cast<ff::ff_t*>(std::malloc(plen));
+  uint8_t* arr = static_cast<uint8_t*>(std::malloc(blen));
+  ff::ff_t* dst = static_cast<ff::ff_t*>(std::malloc(plen));
+
+  for (size_t i = 0; i < ntt::N; i++) {
+    src[i] = ff::ff_t::random();
+  }
+
+  indcpa::encode<l>(src, arr);
+  indcpa::decode<l>(arr, dst);
+
+  for (size_t i = 0; i < ntt::N; i++) {
+    assert((src[i].v & mask) == (dst[i].v & mask));
+  }
+
+  std::free(src);
+  std::free(arr);
+  std::free(dst);
+}
+
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -11,5 +11,19 @@ main()
   std::cout << "[test] (i)NTT over degree-255 polynomial R_q | q = 3329"
             << std::endl;
 
+  test_kyber::test_serialization<12>();
+  test_kyber::test_serialization<11>();
+  test_kyber::test_serialization<10>();
+  test_kyber::test_serialization<9>();
+  test_kyber::test_serialization<8>();
+  test_kyber::test_serialization<7>();
+  test_kyber::test_serialization<6>();
+  test_kyber::test_serialization<5>();
+  test_kyber::test_serialization<4>();
+  test_kyber::test_serialization<3>();
+  test_kyber::test_serialization<2>();
+  test_kyber::test_serialization<1>();
+  std::cout << "[test] Polynomial serialization/ deserialization" << std::endl;
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Implement algorithm 3 of Kyber specification ( as submitted to NIST PQC final round call, see [here](https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip) ) s.t.

- [x] Degree-255 polynomial can be serialized to byte array to length `32*l`
- [x] Byte array of length `32*l` can be deserialized back to degree-255 polynomial
- [x] Ensure functional correctness of implementation

Note, `l` is a configurable parameter s.t. `l` ∈ [1, 12]

> Kyber Prime 3329 has bit-width 12.