### PR TITLE
INDCPA-secure Kyber Encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 # Project Development
 .vscode
 __pycache__
+
+deps

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,25 @@ CXX = g++
 CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
 OPTFLAGS = -O3 -march=native
 IFLAGS = -I ./include
+DEP_IFLAGS = -I ./deps/sha3/include
 
 all: testing
 
-test/a.out: test/main.cpp include/*.hpp
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $< -o $@
+deps/sha3:
+	mkdir -p deps
+	git clone https://github.com/itzmeanjan/sha3.git $@
+
+dep: deps/sha3
+
+test/a.out: test/main.cpp include/*.hpp dep
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DEP_IFLAGS) $< -o $@
 
 testing: test/a.out
 	./$<
 
 clean:
 	find . -name '*.out' -o -name '*.o' -o -name '*.so' -o -name '*.gch' | xargs rm -rf
+	rm -rf deps
 
 format:
 	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla

--- a/include/compression.hpp
+++ b/include/compression.hpp
@@ -1,0 +1,67 @@
+#pragma once
+#include "ff.hpp"
+#include <cmath>
+
+// IND-CPA-secure Public Key Encryption Scheme
+namespace indcpa {
+
+// Compile-time check to ensure that number of bits ( read `d` ) to consider
+// during polynomial coefficient compression/ decompression is within tolerable
+// bounds.
+//
+// See page 5 of Kyber specification, as submitted to NIST PQC final round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip
+constexpr bool
+check_d(const size_t d)
+{
+  // $ python3
+  // >>> import math
+  // >>> a = math.log2(3329) # == 11.700873155140263
+  // >>> math.round(a) # == 12
+  constexpr size_t log2d = 12ul;
+  return d < log2d;
+}
+
+// Given an element x ∈ Z_q | q = 3329, this routine compresses it by discarding
+// some low-order bits, computing y ∈ [0, 2^d) | d < round(log2(q))
+//
+// See top of page 5 of Kyber specification, as submitted to NIST PQC final
+// round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip
+template<const size_t d>
+static ff::ff_t
+compress(const ff::ff_t x) requires(check_d(d))
+{
+  constexpr size_t t0 = 1ul << d;
+
+  const size_t t1 = static_cast<size_t>(x.v) << d;
+  const double t2 = static_cast<double>(t1) / static_cast<double>(ff::Q);
+  const size_t t3 = static_cast<size_t>(std::round(t2));
+  const uint16_t t4 = static_cast<uint16_t>(t3 & (t0 - 1));
+
+  return ff::ff_t{ t4 };
+}
+
+// Given an element x ∈ [0, 2^d) | d < round(log2(q)), this routine decompresses
+// it back to y ∈ Z_q | q = 3329
+//
+// This routine recovers the compressed element with error probability as
+// defined in eq. 2 of Kyber specification.
+//
+// See top of page 5 of Kyber specification, as submitted to NIST PQC final
+// round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip
+template<const size_t d>
+static ff::ff_t
+decompress(const ff::ff_t x) requires(check_d(d))
+{
+  constexpr size_t t0 = 1ul << d;
+
+  const size_t t1 = static_cast<size_t>(ff::Q * x.v);
+  const double t2 = static_cast<double>(t1) / static_cast<double>(t0);
+  const uint16_t t3 = static_cast<uint16_t>(std::round(t2));
+
+  return ff::ff_t{ t3 };
+}
+
+}

--- a/include/compression.hpp
+++ b/include/compression.hpp
@@ -64,4 +64,23 @@ decompress(const ff::ff_t x) requires(check_d(d))
   return ff::ff_t{ t3 };
 }
 
+// Decompression error that can happen for some given `d` s.t.
+//
+// x' = decompress(compress(x, d), d)
+//
+// |(x' - x) mod q| <= round(q / 2 ^ (d + 1))
+//
+// See eq. 2 of Kyber specification, as submitted to NIST PQC final round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip
+template<const size_t d>
+inline static size_t
+compute_error()
+{
+  constexpr double t0 = static_cast<double>(ff::Q);
+  constexpr double t1 = static_cast<double>(1ul << (d + 1));
+
+  const size_t t2 = static_cast<size_t>(std::round(t0 / t1));
+  return t2;
+}
+
 }

--- a/include/decryption.hpp
+++ b/include/decryption.hpp
@@ -1,0 +1,93 @@
+#pragma once
+#include "compression.hpp"
+#include "ntt.hpp"
+#include "serialize.hpp"
+
+// IND-CPA-secure Public Key Encryption Scheme
+namespace indcpa {
+
+// Given (k * 12 * 32) -bytes secret key and (k * du * 32 + dv * 32) -bytes
+// encrypted ( cipher ) text, this routine recovers 32 -bytes plain text which
+// was encrypted using respective public key, which is associated with this
+// secret key.
+//
+// See algorithm 6 defined in Kyber specification, as submitted to NIST PQC
+// final round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip
+template<const size_t k, const size_t du, const size_t dv>
+static void
+decrypt(
+  const uint8_t* const __restrict seckey, // (k * 12 * 32) -bytes secret key
+  const uint8_t* const __restrict enc,    // (k * du * 32 + dv * 32) -bytes
+  uint8_t* const __restrict dec           // 32 -bytes plain text
+)
+{
+  // step 1
+  ff::ff_t u[k * ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t uoff = i * ntt::N;
+    const size_t encoff = i * du * 32;
+
+    decode<du>(enc + encoff, u + uoff);
+
+    for (size_t l = 0; l < ntt::N; l++) {
+      u[uoff + l] = indcpa::decompress<du>(u[uoff + l]);
+    }
+  }
+
+  // step 2
+  ff::ff_t v[ntt::N]{};
+
+  constexpr size_t encoff = k * du * 32;
+  decode<dv>(enc + encoff, v);
+
+  for (size_t i = 0; i < ntt::N; i++) {
+    v[i] = indcpa::decompress<dv>(v[i]);
+  }
+
+  // step 3
+  ff::ff_t s_prime[k * ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t soff = i * ntt::N;
+    const size_t skoff = i * 12 * 32;
+
+    decode<12>(seckey + skoff, s_prime + soff);
+  }
+
+  // step 4
+  ff::ff_t u_prime[k * ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t uoff = i * ntt::N;
+
+    ntt::ntt(u + uoff, u_prime + uoff);
+  }
+
+  ff::ff_t t[ntt::N]{};
+  ff::ff_t tmp[ntt::N]{};
+
+  std::memset(t, 0, sizeof(t));
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t off = i * ntt::N;
+
+    ntt::polymul(s_prime + off, u_prime + off, tmp);
+
+    for (size_t l = 0; l < ntt::N; l++) {
+      t[l] += tmp[l];
+    }
+  }
+
+  ntt::intt(t, tmp);
+  std::memcpy(t, tmp, sizeof(tmp));
+
+  for (size_t i = 0; i < ntt::N; i++) {
+    v[i] = compress<1>(v[i] - t[i]);
+  }
+
+  encode<1>(v, dec);
+}
+
+}

--- a/include/encryption.hpp
+++ b/include/encryption.hpp
@@ -1,0 +1,212 @@
+#pragma once
+#include "compression.hpp"
+#include "ntt.hpp"
+#include "sampling.hpp"
+#include "serialize.hpp"
+#include "shake256.hpp"
+
+// IND-CPA-secure Public Key Encryption Scheme
+namespace indcpa {
+
+// Given (k * 12 * 32 + 32) -bytes public key, 32 -bytes message ( to be
+// encrypted ) and 32 -bytes random coin ( from where all randomness is
+// deterministically sampled ), this routine encrypts message using
+// INDCPA-secure Kyber encryption algorithm, computing compressed cipher text of
+// (k * du * 32 + dv * 32) -bytes.
+//
+// See algorithm 5 defined in Kyber specification, as submitted to NIST PQC
+// final round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip
+template<const size_t k,
+         const size_t eta1,
+         const size_t eta2,
+         const size_t du,
+         const size_t dv>
+static void
+encrypt(const uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes
+        const uint8_t* const __restrict msg,    // 32 -bytes message
+        const uint8_t* const __restrict rcoin,  // 32 -bytes random coin
+        uint8_t* const __restrict enc           // k * du * 32 + dv * 32 -bytes
+)
+{
+  // step 2
+  ff::ff_t t_prime[k * ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t toff = i * ntt::N;
+    const size_t pkoff = i * 12 * 32;
+
+    decode<12>(pubkey + pkoff, t_prime + toff);
+  }
+
+  // step 3
+  constexpr size_t pkoff = k * 12 * 32;
+  const uint8_t* const rho = pubkey + pkoff;
+
+  // step 4, 5, 6, 7, 8
+  uint8_t xof_in[34]{};
+  std::memcpy(xof_in, rho, sizeof(xof_in) - 2);
+
+  ff::ff_t A_prime[k * k * ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    for (size_t j = 0; j < k; j++) {
+      const size_t off = (i * k + j) * ntt::N;
+
+      xof_in[32] = static_cast<uint8_t>(i);
+      xof_in[33] = static_cast<uint8_t>(j);
+
+      shake128::shake128 hasher{};
+      hasher.hash(xof_in, sizeof(xof_in));
+
+      indcpa::parse(&hasher, A_prime + off);
+    }
+  }
+
+  // step 1
+  uint8_t N = 0;
+
+  // step 9, 10, 11, 12
+  uint8_t prf_in[33]{};
+  std::memcpy(prf_in, rcoin, sizeof(prf_in) - 1);
+
+  uint8_t prf_out_eta1[64 * eta1]{};
+  uint8_t prf_out_eta2[64 * eta2]{};
+
+  ff::ff_t r[k * ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t off = i * ntt::N;
+
+    prf_in[32] = N;
+
+    shake256::shake256 hasher{};
+    hasher.hash(prf_in, sizeof(prf_in));
+    hasher.read(prf_out_eta1, sizeof(prf_out_eta1));
+
+    cbd<eta1>(prf_out_eta1, r + off);
+
+    N += 1;
+  }
+
+  // step 13, 14, 15, 16
+  ff::ff_t e1[k * ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t off = i * ntt::N;
+
+    prf_in[32] = N;
+
+    shake256::shake256 hasher{};
+    hasher.hash(prf_in, sizeof(prf_in));
+    hasher.read(prf_out_eta2, sizeof(prf_out_eta2));
+
+    cbd<eta2>(prf_out_eta2, e1 + off);
+
+    N += 1;
+  }
+
+  // step 17
+  ff::ff_t e2[ntt::N]{};
+
+  prf_in[32] = N;
+
+  shake256::shake256 hasher{};
+  hasher.hash(prf_in, sizeof(prf_in));
+  hasher.read(prf_out_eta2, sizeof(prf_out_eta2));
+
+  cbd<eta2>(prf_out_eta2, e2);
+
+  // step 18
+  ff::ff_t r_prime[k * ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t off = i * ntt::N;
+    ntt::ntt(r + off, r_prime + off);
+  }
+
+  // step 19
+  ff::ff_t u[k * ntt::N]{};
+  std::memset(u, 0, sizeof(u));
+
+  ff::ff_t tmp0[ntt::N]{};
+  ff::ff_t tmp1[ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t uoff = i * ntt::N;
+    const size_t e1off = i * ntt::N;
+
+    for (size_t j = 0; j < k; j++) {
+      const size_t aoff = (i * k + j) * ntt::N;
+      const size_t roff = j * ntt::N;
+
+      ntt::polymul(A_prime + aoff, r_prime + roff, tmp0);
+
+      for (size_t l = 0; l < ntt::N; l++) {
+        u[uoff + l] += tmp0[l];
+      }
+    }
+
+    ntt::intt(u + uoff, tmp1);
+    std::memcpy(u + uoff, tmp1, sizeof(tmp1));
+
+    for (size_t l = 0; l < ntt::N; l++) {
+      u[uoff + l] += e1[e1off + l];
+    }
+  }
+
+  // step 20
+  ff::ff_t v[ntt::N]{};
+  std::memset(v, 0, sizeof(v));
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t toff = i * ntt::N;
+    const size_t roff = i * ntt::N;
+
+    ntt::polymul(t_prime + toff, r_prime + roff, tmp0);
+
+    for (size_t l = 0; l < ntt::N; l++) {
+      v[l] += tmp0[l];
+    }
+  }
+
+  ntt::intt(v, tmp1);
+  std::memcpy(v, tmp1, sizeof(tmp1));
+
+  for (size_t i = 0; i < ntt::N; i++) {
+    v[i] += e2[i];
+  }
+
+  ff::ff_t m[ntt::N]{};
+  indcpa::decode<1>(msg, m);
+
+  for (size_t i = 0; i < ntt::N; i++) {
+    m[i] = indcpa::decompress<1>(m[i]);
+  }
+
+  for (size_t i = 0; i < ntt::N; i++) {
+    v[i] += m[i];
+  }
+
+  // step 21
+  for (size_t i = 0; i < k; i++) {
+    const size_t uoff = i * ntt::N;
+    const size_t encoff = i * du * 32;
+
+    for (size_t l = 0; l < ntt ::N; l++) {
+      u[uoff + l] = indcpa::compress<du>(u[uoff + l]);
+    }
+
+    encode<du>(u + uoff, enc + encoff);
+  }
+
+  // step 22
+  for (size_t i = 0; i < ntt ::N; i++) {
+    v[i] = indcpa::compress<dv>(v[i]);
+  }
+
+  constexpr size_t encoff = k * du * 32;
+  encode<dv>(v, enc + encoff);
+}
+
+}

--- a/include/test_compression.hpp
+++ b/include/test_compression.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include "compression.hpp"
+#include <cassert>
+#include <iostream>
+
+// Test functional correctness of Kyber PQC suite implementation
+namespace test_kyber {
+
+// Test functional correctness of compression/ decompression logic s.t. given an
+// element x ∈ Z_q following is satisfied
+//
+// x' = decompress(compress(x, d), d)
+//
+// |(x' - x) mod q| <= round(q / 2 ^ (d + 1))
+//
+// This test is executed a few times on some random Z_q elements, for some
+// specified `d`.
+template<const size_t d>
+static void
+test_compression()
+{
+  constexpr size_t cnt = 1024;
+
+  for (size_t i = 0; i < cnt; i++) {
+    const auto a = ff::ff_t::random();
+
+    const auto b = indcpa::compress<d>(a);
+    const auto c = indcpa::decompress<d>(b);
+
+    const uint16_t br0[]{ static_cast<uint16_t>(ff::Q - c.v), c.v };
+    const bool flg0 = c.v <= (ff::Q >> 1);
+    const auto c_prime = static_cast<int32_t>(br0[flg0]);
+
+    const uint16_t br1[]{ static_cast<uint16_t>(ff::Q - a.v), a.v };
+    const bool flg1 = a.v <= (ff::Q >> 1);
+    const auto a_prime = static_cast<int32_t>(br1[flg1]);
+
+    const size_t err = static_cast<size_t>(std::abs(c_prime - a_prime));
+    const size_t terr = indcpa::compute_error<d>();
+
+    assert(err <= terr);
+  }
+}
+
+}

--- a/include/test_compression.hpp
+++ b/include/test_compression.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "compression.hpp"
 #include <cassert>
-#include <iostream>
 
 // Test functional correctness of Kyber PQC suite implementation
 namespace test_kyber {

--- a/include/test_cpa_pke.hpp
+++ b/include/test_cpa_pke.hpp
@@ -1,0 +1,62 @@
+#pragma once
+#include "decryption.hpp"
+#include "encryption.hpp"
+#include "keygen.hpp"
+#include <cassert>
+
+// Test functional correctness of Kyber PQC suite implementation
+namespace test_kyber {
+
+// Given k, η1, η2, du, dv - Kyber parameters, this routine checks whether
+//
+// - A random key pair can be generated
+// - Public key can be used for encrypting 32 -bytes random message
+// - Secret key can decrypt (k * du * 32 + dv * 32) -bytes cipher text to 32
+// -bytes plain text
+//
+// works as expected.
+template<const size_t k,
+         const size_t eta1,
+         const size_t eta2,
+         const size_t du,
+         const size_t dv>
+static void
+test_kyber_cpa_pke()
+{
+  constexpr size_t pklen = k * 12 * 32 + 32;
+  constexpr size_t sklen = k * 12 * 32;
+  constexpr size_t mlen = 32;
+  constexpr size_t enclen = k * du * 32 + dv * 32;
+
+  uint8_t* pkey = static_cast<uint8_t*>(std::malloc(pklen));
+  uint8_t* skey = static_cast<uint8_t*>(std::malloc(sklen));
+  uint8_t* rcoin = static_cast<uint8_t*>(std::malloc(mlen));
+  uint8_t* txt = static_cast<uint8_t*>(std::malloc(mlen));
+  uint8_t* enc = static_cast<uint8_t*>(std::malloc(enclen));
+  uint8_t* dec = static_cast<uint8_t*>(std::malloc(mlen));
+
+  std::memset(pkey, 0, pklen);
+  std::memset(skey, 0, sklen);
+  std::memset(enc, 0, enclen);
+  std::memset(dec, 0, mlen);
+
+  random_data<uint8_t>(txt, mlen);
+  random_data<uint8_t>(rcoin, mlen);
+
+  indcpa::keygen<k, eta1>(pkey, skey);
+  indcpa::encrypt<k, eta1, eta2, du, dv>(pkey, txt, rcoin, enc);
+  indcpa::decrypt<k, du, dv>(skey, enc, dec);
+
+  for (size_t i = 0; i < mlen; i++) {
+    assert((txt[i] ^ dec[i]) == 0);
+  }
+
+  std::free(pkey);
+  std::free(skey);
+  std::free(rcoin);
+  std::free(txt);
+  std::free(enc);
+  std::free(dec);
+}
+
+}

--- a/include/test_kyber.hpp
+++ b/include/test_kyber.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "test_compression.hpp"
+#include "test_cpa_pke.hpp"
 #include "test_ff.hpp"
 #include "test_ntt.hpp"
 #include "test_serialize.hpp"

--- a/include/test_kyber.hpp
+++ b/include/test_kyber.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "test_compression.hpp"
 #include "test_ff.hpp"
 #include "test_ntt.hpp"
 #include "test_serialize.hpp"

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -32,5 +32,10 @@ main()
   test_kyber::test_compression<1>();
   std::cout << "[test] Coefficient compression/ decompression" << std::endl;
 
+  test_kyber::test_kyber_cpa_pke<2, 3, 2, 10, 4>(); // kyber-512
+  test_kyber::test_kyber_cpa_pke<3, 2, 2, 10, 4>(); // kyber-768
+  test_kyber::test_kyber_cpa_pke<4, 2, 2, 11, 5>(); // kyber-1024
+  std::cout << "[test] INDCPA-secure Public Key Encryption" << std::endl;
+
   return EXIT_SUCCESS;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -25,5 +25,12 @@ main()
   test_kyber::test_serialization<1>();
   std::cout << "[test] Polynomial serialization/ deserialization" << std::endl;
 
+  test_kyber::test_compression<11>();
+  test_kyber::test_compression<10>();
+  test_kyber::test_compression<5>();
+  test_kyber::test_compression<4>();
+  test_kyber::test_compression<1>();
+  std::cout << "[test] Coefficient compression/ decompression" << std::endl;
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR implements Kyber INDCPA-secure public key encryption algorithm ( no. 5 ), as defined in Kyber specification.

> Find Kyber specification in NIST PQC final round submission [package](https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip)

## API Usage Example

```cpp
// kyber_enc.cpp
//
// Demonstrates usage of API using Kyber-512 parameters

#include "encryption.hpp"
#include "keygen.hpp"
#include <iostream>

int
main()
{
  constexpr size_t k = 2;
  constexpr size_t eta1 = 3;
  constexpr size_t eta2 = 2;
  constexpr size_t du = 10;
  constexpr size_t dv = 4;

  constexpr size_t pklen = k * 12 * 32 + 32;
  constexpr size_t sklen = k * 12 * 32;
  constexpr size_t enclen = k * du * 32 + dv * 32;

  uint8_t pubkey[pklen]{};
  uint8_t seckey[sklen]{};
  uint8_t msg[32]{};
  uint8_t rcoin[32]{};
  uint8_t enc[enclen]{};

  std::memset(msg, 0, sizeof(msg));
  std::memset(rcoin, 0, sizeof(rcoin));

  indcpa::keygen<k, eta1>(pubkey, seckey);
  indcpa::encrypt<k, eta1, eta2, du, dv>(pubkey, msg, rcoin, enc);

  std::cout << "pubkey : " << to_hex(pubkey, sizeof(pubkey)) << "\n\n";
  std::cout << "seckey : " << to_hex(seckey, sizeof(seckey)) << "\n\n";
  std::cout << "cipher : " << to_hex(enc, sizeof(enc)) << "\n";

  return EXIT_SUCCESS;
}
```

Build ( and run ) using

```fish
git clone https://github.com/itzmeanjan/sha3.git
g++ -Wall -Wextra -std=c++20 -I include -I sha3/include kyber_enc.cpp && ./a.out
```