### PR TITLE
INDCPA-secure Decryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 # Project Development
 .vscode
 __pycache__
+
+deps

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,25 @@ CXX = g++
 CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
 OPTFLAGS = -O3 -march=native
 IFLAGS = -I ./include
+DEP_IFLAGS = -I ./deps/sha3/include
 
 all: testing
 
-test/a.out: test/main.cpp include/*.hpp
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $< -o $@
+deps/sha3:
+	mkdir -p deps
+	git clone https://github.com/itzmeanjan/sha3.git $@
+
+dep: deps/sha3
+
+test/a.out: test/main.cpp include/*.hpp dep
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DEP_IFLAGS) $< -o $@
 
 testing: test/a.out
 	./$<
 
 clean:
 	find . -name '*.out' -o -name '*.o' -o -name '*.so' -o -name '*.gch' | xargs rm -rf
+	rm -rf deps
 
 format:
 	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla

--- a/include/decryption.hpp
+++ b/include/decryption.hpp
@@ -1,0 +1,93 @@
+#pragma once
+#include "compression.hpp"
+#include "ntt.hpp"
+#include "serialize.hpp"
+
+// IND-CPA-secure Public Key Encryption Scheme
+namespace indcpa {
+
+// Given (k * 12 * 32) -bytes secret key and (k * du * 32 + dv * 32) -bytes
+// encrypted ( cipher ) text, this routine recovers 32 -bytes plain text which
+// was encrypted using respective public key, which is associated with this
+// secret key.
+//
+// See algorithm 6 defined in Kyber specification, as submitted to NIST PQC
+// final round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip
+template<const size_t k, const size_t du, const size_t dv>
+static void
+decrypt(
+  const uint8_t* const __restrict seckey, // (k * 12 * 32) -bytes secret key
+  const uint8_t* const __restrict enc,    // (k * du * 32 + dv * 32) -bytes
+  uint8_t* const __restrict dec           // 32 -bytes plain text
+)
+{
+  // step 1
+  ff::ff_t u[k * ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t uoff = i * ntt::N;
+    const size_t encoff = i * du * 32;
+
+    decode<du>(enc + encoff, u + uoff);
+
+    for (size_t l = 0; l < ntt::N; l++) {
+      u[uoff + l] = indcpa::decompress<du>(u[uoff + l]);
+    }
+  }
+
+  // step 2
+  ff::ff_t v[ntt::N]{};
+
+  constexpr size_t encoff = k * du * 32;
+  decode<dv>(enc + encoff, v);
+
+  for (size_t i = 0; i < ntt::N; i++) {
+    v[i] = indcpa::decompress<dv>(v[i]);
+  }
+
+  // step 3
+  ff::ff_t s_prime[k * ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t soff = i * ntt::N;
+    const size_t skoff = i * 12 * 32;
+
+    decode<12>(seckey + skoff, s_prime + soff);
+  }
+
+  // step 4
+  ff::ff_t u_prime[k * ntt::N]{};
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t uoff = i * ntt::N;
+
+    ntt::ntt(u + uoff, u_prime + uoff);
+  }
+
+  ff::ff_t t[ntt::N]{};
+  ff::ff_t tmp[ntt::N]{};
+
+  std::memset(t, 0, sizeof(t));
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t off = i * ntt::N;
+
+    ntt::polymul(s_prime + off, u_prime + off, tmp);
+
+    for (size_t l = 0; l < ntt::N; l++) {
+      t[l] += tmp[l];
+    }
+  }
+
+  ntt::intt(t, tmp);
+  std::memcpy(t, tmp, sizeof(tmp));
+
+  for (size_t i = 0; i < ntt::N; i++) {
+    v[i] = compress<1>(v[i] - t[i]);
+  }
+
+  encode<1>(v, dec);
+}
+
+}

--- a/include/test_compression.hpp
+++ b/include/test_compression.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "compression.hpp"
 #include <cassert>
-#include <iostream>
 
 // Test functional correctness of Kyber PQC suite implementation
 namespace test_kyber {

--- a/include/test_cpa_pke.hpp
+++ b/include/test_cpa_pke.hpp
@@ -1,0 +1,62 @@
+#pragma once
+#include "decryption.hpp"
+#include "encryption.hpp"
+#include "keygen.hpp"
+#include <cassert>
+
+// Test functional correctness of Kyber PQC suite implementation
+namespace test_kyber {
+
+// Given k, η1, η2, du, dv - Kyber parameters, this routine checks whether
+//
+// - A random key pair can be generated
+// - Public key can be used for encrypting 32 -bytes random message
+// - Secret key can decrypt (k * du * 32 + dv * 32) -bytes cipher text to 32
+// -bytes plain text
+//
+// works as expected.
+template<const size_t k,
+         const size_t eta1,
+         const size_t eta2,
+         const size_t du,
+         const size_t dv>
+static void
+test_kyber_cpa_pke()
+{
+  constexpr size_t pklen = k * 12 * 32 + 32;
+  constexpr size_t sklen = k * 12 * 32;
+  constexpr size_t mlen = 32;
+  constexpr size_t enclen = k * du * 32 + dv * 32;
+
+  uint8_t* pkey = static_cast<uint8_t*>(std::malloc(pklen));
+  uint8_t* skey = static_cast<uint8_t*>(std::malloc(sklen));
+  uint8_t* rcoin = static_cast<uint8_t*>(std::malloc(mlen));
+  uint8_t* txt = static_cast<uint8_t*>(std::malloc(mlen));
+  uint8_t* enc = static_cast<uint8_t*>(std::malloc(enclen));
+  uint8_t* dec = static_cast<uint8_t*>(std::malloc(mlen));
+
+  std::memset(pkey, 0, pklen);
+  std::memset(skey, 0, sklen);
+  std::memset(enc, 0, enclen);
+  std::memset(dec, 0, mlen);
+
+  random_data<uint8_t>(txt, mlen);
+  random_data<uint8_t>(rcoin, mlen);
+
+  indcpa::keygen<k, eta1>(pkey, skey);
+  indcpa::encrypt<k, eta1, eta2, du, dv>(pkey, txt, rcoin, enc);
+  indcpa::decrypt<k, du, dv>(skey, enc, dec);
+
+  for (size_t i = 0; i < mlen; i++) {
+    assert((txt[i] ^ dec[i]) == 0);
+  }
+
+  std::free(pkey);
+  std::free(skey);
+  std::free(rcoin);
+  std::free(txt);
+  std::free(enc);
+  std::free(dec);
+}
+
+}

--- a/include/test_kyber.hpp
+++ b/include/test_kyber.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "test_compression.hpp"
+#include "test_cpa_pke.hpp"
 #include "test_ff.hpp"
 #include "test_ntt.hpp"
 #include "test_serialize.hpp"

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -32,5 +32,10 @@ main()
   test_kyber::test_compression<1>();
   std::cout << "[test] Coefficient compression/ decompression" << std::endl;
 
+  test_kyber::test_kyber_cpa_pke<2, 3, 2, 10, 4>(); // kyber-512
+  test_kyber::test_kyber_cpa_pke<3, 2, 2, 10, 4>(); // kyber-768
+  test_kyber::test_kyber_cpa_pke<4, 2, 2, 11, 5>(); // kyber-1024
+  std::cout << "[test] INDCPA-secure Public Key Encryption" << std::endl;
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR implements Kyber INDCPA-secure public key decryption algorithm ( no. 6 ), as defined in Kyber specification.

> Find Kyber specification in NIST PQC final round submission [package](https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip)

## Using `keygen`, `encrypt` & `decrypt` API

```c++
// kyber_indcpa.cpp
//
// With Kyber-512 parameter set

#include "decryption.hpp"
#include "encryption.hpp"
#include "keygen.hpp"
#include <iostream>

int
main()
{
  constexpr size_t k = 2;
  constexpr size_t eta1 = 3;
  constexpr size_t eta2 = 2;
  constexpr size_t du = 10;
  constexpr size_t dv = 4;

  constexpr size_t pklen = k * 12 * 32 + 32;
  constexpr size_t sklen = k * 12 * 32;
  constexpr size_t enclen = k * du * 32 + dv * 32;

  uint8_t pubkey[pklen]{};
  uint8_t seckey[sklen]{};

  uint8_t rcoin[32]{};
  uint8_t msg[32]{};
  uint8_t enc[enclen]{};

  uint8_t dec[32]{};

  random_data<uint8_t>(msg, sizeof(msg));
  random_data<uint8_t>(rcoin, sizeof(rcoin));

  std::memset(enc, 0, sizeof(enc));
  std::memset(dec, 0, sizeof(dec));

  indcpa::keygen<k, eta1>(pubkey, seckey);
  indcpa::encrypt<k, eta1, eta2, du, dv>(pubkey, msg, rcoin, enc);
  indcpa::decrypt<k, du, dv>(seckey, enc, dec);

  std::cout << "pubkey : " << to_hex(pubkey, sizeof(pubkey)) << "\n\n";
  std::cout << "seckey : " << to_hex(seckey, sizeof(seckey)) << "\n\n";

  std::cout << "plain text : " << to_hex(msg, sizeof(msg)) << "\n\n";
  std::cout << "cipher : " << to_hex(enc, sizeof(enc)) << "\n\n";
  std::cout << "decrypted : " << to_hex(dec, sizeof(dec)) << "\n\n";

  return EXIT_SUCCESS;
}
```

For building ( and executing ) this program

```fish
git clone https://github.com/itzmeanjan/sha3.git
g++ -Wall -Wextra -std=c++20 -I include -I sha3/include kyber_indcpa.cpp && ./a.out
```