### PR TITLE
Optimize Kyber

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -15,6 +15,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup Compiler
       run: sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10; sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
+    - name: Fetch Dependency
+      run: git submodule update --init
     - name: Execute Tests
       run: make
     - name: Cleanup

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sha3"]
+	path = sha3
+	url = https://github.com/itzmeanjan/sha3.git

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXX = clang++
+CXX = g++
 CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
 OPTFLAGS = -O3 -march=native
 IFLAGS = -I ./include
@@ -14,7 +14,6 @@ testing: test/a.out
 
 clean:
 	find . -name '*.out' -o -name '*.o' -o -name '*.so' -o -name '*.gch' | xargs rm -rf
-	rm -rf deps
 
 format:
 	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,12 @@
-CXX = g++
+CXX = clang++
 CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
 OPTFLAGS = -O3 -march=native
 IFLAGS = -I ./include
-DEP_IFLAGS = -I ./deps/sha3/include
+DEP_IFLAGS = -I ./sha3/include
 
 all: testing
 
-deps/sha3:
-	mkdir -p deps
-	git clone https://github.com/itzmeanjan/sha3.git $@
-	cd deps/sha3; git checkout 5886375; cd -
-
-dep: deps/sha3
-
-test/a.out: test/main.cpp include/*.hpp dep
+test/a.out: test/main.cpp include/*.hpp sha3/include/*.hpp
 	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DEP_IFLAGS) $< -o $@
 
 testing: test/a.out
@@ -26,7 +19,7 @@ clean:
 format:
 	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla
 
-bench/a.out: bench/main.cpp include/*.hpp dep
+bench/a.out: bench/main.cpp include/*.hpp sha3/include/*.hpp
 	# make sure you've google-benchmark globally installed;
 	# see https://github.com/google/benchmark/tree/60b16f1#installation
 	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DEP_IFLAGS) $< -lbenchmark -o $@

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -4,8 +4,10 @@
 BENCHMARK(bench_kyber::ff_add);
 BENCHMARK(bench_kyber::ff_compound_add);
 BENCHMARK(bench_kyber::ff_sub);
+BENCHMARK(bench_kyber::ff_compound_sub);
 BENCHMARK(bench_kyber::ff_neg);
 BENCHMARK(bench_kyber::ff_mul);
+BENCHMARK(bench_kyber::ff_compound_mul);
 BENCHMARK(bench_kyber::ff_inv);
 BENCHMARK(bench_kyber::ff_div);
 BENCHMARK(bench_kyber::ff_exp);

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -43,6 +43,9 @@ BENCHMARK(bench_kyber::ntt);
 BENCHMARK(bench_kyber::intt);
 BENCHMARK(bench_kyber::polymul);
 
+// register for benchmarking random byte generation using system randomness
+BENCHMARK(bench_kyber::random_data<32>);
+
 // register for benchmarking IND-CPA-secure Kyber Public Key Encryption
 BENCHMARK(bench_kyber::pke_keygen<2, 3>);        // kyber512
 BENCHMARK(bench_kyber::encrypt<2, 3, 2, 10, 4>); // kyber512

--- a/include/bench_ff.hpp
+++ b/include/bench_ff.hpp
@@ -80,6 +80,31 @@ ff_sub(benchmark::State& state)
   assert(c == b);
 }
 
+// Benchmark compound subtraction over prime field Z_q | q = 3329
+void
+ff_compound_sub(benchmark::State& state)
+{
+  ff::ff_t a = ff::ff_t::random();
+  ff::ff_t b{};
+
+  for (auto _ : state) {
+    b -= a;
+
+    benchmark::DoNotOptimize(b);
+    benchmark::DoNotOptimize(a);
+    benchmark::ClobberMemory();
+  }
+
+  const size_t itr = state.iterations();
+
+  ff::ff_t c{};
+  for (size_t i = 0; i < itr; i++) {
+    c = c - a;
+  }
+
+  assert(c == b);
+}
+
 // Benchmark negation over prime field Z_q | q = 3329
 void
 ff_neg(benchmark::State& state)
@@ -108,6 +133,31 @@ ff_mul(benchmark::State& state)
 
   for (auto _ : state) {
     b = b * a;
+
+    benchmark::DoNotOptimize(b);
+    benchmark::DoNotOptimize(a);
+    benchmark::ClobberMemory();
+  }
+
+  const size_t itr = state.iterations();
+
+  ff::ff_t c{ 1 };
+  for (size_t i = 0; i < itr; i++) {
+    c = c * a;
+  }
+
+  assert(c == b);
+}
+
+// Benchmark compound multiplication over prime field Z_q | q = 3329
+void
+ff_compound_mul(benchmark::State& state)
+{
+  ff::ff_t a = ff::ff_t::random();
+  ff::ff_t b{ 1 };
+
+  for (auto _ : state) {
+    b *= a;
 
     benchmark::DoNotOptimize(b);
     benchmark::DoNotOptimize(a);

--- a/include/bench_kyber.hpp
+++ b/include/bench_kyber.hpp
@@ -5,3 +5,4 @@
 #include "bench_ntt.hpp"
 #include "bench_pke_kyber.hpp"
 #include "bench_serialize.hpp"
+#include "bench_utils.hpp"

--- a/include/bench_ntt.hpp
+++ b/include/bench_ntt.hpp
@@ -12,24 +12,28 @@ ntt(benchmark::State& state)
 {
   ff::ff_t poly_a[ntt::N]{};
   ff::ff_t poly_b[ntt::N]{};
-  ff::ff_t poly_c[ntt::N]{};
 
   for (size_t i = 0; i < ntt::N; i++) {
     poly_a[i] = ff::ff_t::random();
   }
 
-  for (auto _ : state) {
-    ntt::ntt(poly_a, poly_b);
+  std::memcpy(poly_b, poly_a, sizeof(ff::ff_t) * ntt::N);
 
-    benchmark::DoNotOptimize(poly_a);
+  for (auto _ : state) {
+    ntt::ntt(poly_b);
+
     benchmark::DoNotOptimize(poly_b);
     benchmark::ClobberMemory();
   }
 
-  ntt::intt(poly_b, poly_c);
+  const size_t itr = state.iterations();
+
+  for (size_t i = 0; i < itr; i++) {
+    ntt::ntt(poly_a);
+  }
 
   for (size_t i = 0; i < ntt::N; i++) {
-    assert(poly_a[i] == poly_c[i]);
+    assert(poly_a[i] == poly_b[i]);
   }
 }
 
@@ -40,24 +44,28 @@ intt(benchmark::State& state)
 {
   ff::ff_t poly_a[ntt::N]{};
   ff::ff_t poly_b[ntt::N]{};
-  ff::ff_t poly_c[ntt::N]{};
 
   for (size_t i = 0; i < ntt::N; i++) {
     poly_a[i] = ff::ff_t::random();
   }
 
-  ntt::ntt(poly_a, poly_b);
+  std::memcpy(poly_b, poly_a, sizeof(ff::ff_t) * ntt::N);
 
   for (auto _ : state) {
-    ntt::intt(poly_b, poly_c);
+    ntt::intt(poly_b);
 
     benchmark::DoNotOptimize(poly_b);
-    benchmark::DoNotOptimize(poly_c);
     benchmark::ClobberMemory();
   }
 
+  const size_t itr = state.iterations();
+
+  for (size_t i = 0; i < itr; i++) {
+    ntt::intt(poly_a);
+  }
+
   for (size_t i = 0; i < ntt::N; i++) {
-    assert(poly_a[i] == poly_c[i]);
+    assert(poly_a[i] == poly_b[i]);
   }
 }
 

--- a/include/bench_pke_kyber.hpp
+++ b/include/bench_pke_kyber.hpp
@@ -59,8 +59,8 @@ encrypt(benchmark::State& state)
   std::memset(skey, 0, sklen);
   std::memset(enc, 0, enclen);
 
-  random_data<uint8_t>(txt, mlen);
-  random_data<uint8_t>(rcoin, mlen);
+  kyber_utils::random_data<uint8_t>(txt, mlen);
+  kyber_utils::random_data<uint8_t>(rcoin, mlen);
 
   cpapke::keygen<k, eta1>(pkey, skey);
 
@@ -109,8 +109,8 @@ decrypt(benchmark::State& state)
   std::memset(enc, 0, enclen);
   std::memset(dec, 0, mlen);
 
-  random_data<uint8_t>(txt, mlen);
-  random_data<uint8_t>(rcoin, mlen);
+  kyber_utils::random_data<uint8_t>(txt, mlen);
+  kyber_utils::random_data<uint8_t>(rcoin, mlen);
 
   cpapke::keygen<k, eta1>(pkey, skey);
   cpapke::encrypt<k, eta1, eta2, du, dv>(pkey, txt, rcoin, enc);

--- a/include/bench_utils.hpp
+++ b/include/bench_utils.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include "utils.hpp"
+#include <benchmark/benchmark.h>
+
+// Benchmark Kyber PQC suite implementation on CPU, using google-benchmark
+namespace bench_kyber {
+
+// Benchmark random byte array ( of length N ) generation using system
+// randomness
+template<const size_t len>
+void
+random_data(benchmark::State& state)
+{
+  uint8_t data[len]{};
+
+  for (auto _ : state) {
+    kyber_utils::random_data<uint8_t>(data, len);
+
+    benchmark::DoNotOptimize(data);
+    benchmark::ClobberMemory();
+  }
+}
+
+}

--- a/include/compression.hpp
+++ b/include/compression.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "ff.hpp"
+#include "ntt.hpp"
 #include <cmath>
 
 // IND-CPA-secure Public Key Encryption Scheme Utilities
@@ -29,7 +30,7 @@ check_d(const size_t d)
 // round call
 // https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip
 template<const size_t d>
-static ff::ff_t
+inline static ff::ff_t
 compress(const ff::ff_t x) requires(check_d(d))
 {
   constexpr uint16_t t0 = 1u << d;
@@ -58,7 +59,7 @@ compress(const ff::ff_t x) requires(check_d(d))
 // round call
 // https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Kyber-Round3.zip
 template<const size_t d>
-static ff::ff_t
+inline static ff::ff_t
 decompress(const ff::ff_t x) requires(check_d(d))
 {
   constexpr uint32_t t0 = 1u << d;
@@ -93,6 +94,28 @@ compute_error()
 
   const size_t t2 = static_cast<size_t>(std::round(t0 / t1));
   return t2;
+}
+
+// Utility function to compress each of 256 coefficients of a degree-255
+// polynomial s.t. input polynomial is mutated.
+template<const size_t d>
+inline static void
+poly_compress(ff::ff_t* const __restrict poly) requires(check_d(d))
+{
+  for (size_t i = 0; i < ntt::N; i++) {
+    poly[i] = compress<d>(poly[i]);
+  }
+}
+
+// Utility function to decompress each of 256 coefficients of a degree-255
+// polynomial s.t. input polynomial is mutated.
+template<const size_t d>
+inline static void
+poly_decompress(ff::ff_t* const __restrict poly) requires(check_d(d))
+{
+  for (size_t i = 0; i < ntt::N; i++) {
+    poly[i] = decompress<d>(poly[i]);
+  }
 }
 
 }

--- a/include/decryption.hpp
+++ b/include/decryption.hpp
@@ -57,12 +57,9 @@ decrypt(
   }
 
   // step 4
-  ff::ff_t u_prime[k * ntt::N]{};
-
   for (size_t i = 0; i < k; i++) {
     const size_t uoff = i * ntt::N;
-
-    ntt::ntt(u + uoff, u_prime + uoff);
+    ntt::ntt(u + uoff);
   }
 
   ff::ff_t t[ntt::N]{};
@@ -73,15 +70,14 @@ decrypt(
   for (size_t i = 0; i < k; i++) {
     const size_t off = i * ntt::N;
 
-    ntt::polymul(s_prime + off, u_prime + off, tmp);
+    ntt::polymul(s_prime + off, u + off, tmp);
 
     for (size_t l = 0; l < ntt::N; l++) {
       t[l] += tmp[l];
     }
   }
 
-  ntt::intt(t, tmp);
-  std::memcpy(t, tmp, sizeof(tmp));
+  ntt::intt(t);
 
   for (size_t i = 0; i < ntt::N; i++) {
     v[i] = kyber_utils::compress<1>(v[i] - t[i]);

--- a/include/decryption.hpp
+++ b/include/decryption.hpp
@@ -74,7 +74,7 @@ decrypt(
   ntt::intt(t);
 
   for (size_t i = 0; i < ntt::N; i++) {
-    v[i] = v[i] - t[i];
+    v[i] -= t[i];
   }
 
   kyber_utils::poly_compress<1>(v);

--- a/include/decryption.hpp
+++ b/include/decryption.hpp
@@ -30,10 +30,7 @@ decrypt(
     const size_t encoff = i * du * 32;
 
     kyber_utils::decode<du>(enc + encoff, u + uoff);
-
-    for (size_t l = 0; l < ntt::N; l++) {
-      u[uoff + l] = kyber_utils::decompress<du>(u[uoff + l]);
-    }
+    kyber_utils::poly_decompress<du>(u + uoff);
   }
 
   // step 2
@@ -41,10 +38,7 @@ decrypt(
 
   constexpr size_t encoff = k * du * 32;
   kyber_utils::decode<dv>(enc + encoff, v);
-
-  for (size_t i = 0; i < ntt::N; i++) {
-    v[i] = kyber_utils::decompress<dv>(v[i]);
-  }
+  kyber_utils::poly_decompress<dv>(v);
 
   // step 3
   ff::ff_t s_prime[k * ntt::N]{};
@@ -80,9 +74,10 @@ decrypt(
   ntt::intt(t);
 
   for (size_t i = 0; i < ntt::N; i++) {
-    v[i] = kyber_utils::compress<1>(v[i] - t[i]);
+    v[i] = v[i] - t[i];
   }
 
+  kyber_utils::poly_compress<1>(v);
   kyber_utils::encode<1>(v, dec);
 }
 

--- a/include/encapsulation.hpp
+++ b/include/encapsulation.hpp
@@ -40,7 +40,7 @@ encapsulate(const uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes
   uint8_t g_out[64]{};
   uint8_t kdf_in[64]{};
 
-  random_data<uint8_t>(m, sizeof(m));
+  kyber_utils::random_data<uint8_t>(m, sizeof(m));
 
   sha3_256::hash(m, sizeof(m), g_in);
   sha3_256::hash(pubkey, pklen, g_in + 32);

--- a/include/encryption.hpp
+++ b/include/encryption.hpp
@@ -118,19 +118,16 @@ encrypt(const uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes
   kyber_utils::cbd<eta2>(prf_out_eta2, e2);
 
   // step 18
-  ff::ff_t r_prime[k * ntt::N]{};
-
   for (size_t i = 0; i < k; i++) {
     const size_t off = i * ntt::N;
-    ntt::ntt(r + off, r_prime + off);
+    ntt::ntt(r + off);
   }
 
   // step 19
   ff::ff_t u[k * ntt::N]{};
   std::memset(u, 0, sizeof(u));
 
-  ff::ff_t tmp0[ntt::N]{};
-  ff::ff_t tmp1[ntt::N]{};
+  ff::ff_t tmp[ntt::N]{};
 
   for (size_t i = 0; i < k; i++) {
     const size_t uoff = i * ntt::N;
@@ -140,15 +137,14 @@ encrypt(const uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes
       const size_t aoff = (i * k + j) * ntt::N;
       const size_t roff = j * ntt::N;
 
-      ntt::polymul(A_prime + aoff, r_prime + roff, tmp0);
+      ntt::polymul(A_prime + aoff, r + roff, tmp);
 
       for (size_t l = 0; l < ntt::N; l++) {
-        u[uoff + l] += tmp0[l];
+        u[uoff + l] += tmp[l];
       }
     }
 
-    ntt::intt(u + uoff, tmp1);
-    std::memcpy(u + uoff, tmp1, sizeof(tmp1));
+    ntt::intt(u + uoff);
 
     for (size_t l = 0; l < ntt::N; l++) {
       u[uoff + l] += e1[e1off + l];
@@ -163,15 +159,14 @@ encrypt(const uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes
     const size_t toff = i * ntt::N;
     const size_t roff = i * ntt::N;
 
-    ntt::polymul(t_prime + toff, r_prime + roff, tmp0);
+    ntt::polymul(t_prime + toff, r + roff, tmp);
 
     for (size_t l = 0; l < ntt::N; l++) {
-      v[l] += tmp0[l];
+      v[l] += tmp[l];
     }
   }
 
-  ntt::intt(v, tmp1);
-  std::memcpy(v, tmp1, sizeof(tmp1));
+  ntt::intt(v);
 
   for (size_t i = 0; i < ntt::N; i++) {
     v[i] += e2[i];

--- a/include/encryption.hpp
+++ b/include/encryption.hpp
@@ -174,10 +174,7 @@ encrypt(const uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes
 
   ff::ff_t m[ntt::N]{};
   kyber_utils::decode<1>(msg, m);
-
-  for (size_t i = 0; i < ntt::N; i++) {
-    m[i] = kyber_utils::decompress<1>(m[i]);
-  }
+  kyber_utils::poly_decompress<1>(m);
 
   for (size_t i = 0; i < ntt::N; i++) {
     v[i] += m[i];
@@ -188,19 +185,14 @@ encrypt(const uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes
     const size_t uoff = i * ntt::N;
     const size_t encoff = i * du * 32;
 
-    for (size_t l = 0; l < ntt ::N; l++) {
-      u[uoff + l] = kyber_utils::compress<du>(u[uoff + l]);
-    }
-
+    kyber_utils::poly_compress<du>(u + uoff);
     kyber_utils::encode<du>(u + uoff, enc + encoff);
   }
 
   // step 22
-  for (size_t i = 0; i < ntt ::N; i++) {
-    v[i] = kyber_utils::compress<dv>(v[i]);
-  }
-
   constexpr size_t encoff = k * du * 32;
+
+  kyber_utils::poly_compress<dv>(v);
   kyber_utils::encode<dv>(v, enc + encoff);
 }
 

--- a/include/ff.hpp
+++ b/include/ff.hpp
@@ -119,11 +119,21 @@ struct ff_t
   // Computes canonical form of prime field subtraction
   constexpr ff_t operator-(const ff_t& rhs) const
   {
-    const uint16_t t0 = Q + this->v - rhs.v;
+    const uint16_t t0 = (Q + this->v) - rhs.v;
     const bool flg = t0 >= Q;
     const uint16_t t1 = t0 - flg * Q;
 
     return ff_t{ t1 };
+  }
+
+  // Computes canonical form of prime field compound subtraction
+  constexpr void operator-=(const ff_t& rhs)
+  {
+    const uint16_t t0 = (Q + this->v) - rhs.v;
+    const bool flg = t0 >= Q;
+    const uint16_t t1 = t0 - flg * Q;
+
+    this->v = t1;
   }
 
   // Computes canonical form of prime field negation
@@ -156,6 +166,25 @@ struct ff_t
     const uint16_t t7 = t6 - flg * Q;
 
     return ff_t{ t7 };
+  }
+
+  // Computes canonical form of compound modular multiplication
+  // over Z_q | q = 3329
+  constexpr void operator*=(const ff_t& rhs)
+  {
+    const uint32_t t0 = static_cast<uint32_t>(this->v);
+    const uint32_t t1 = static_cast<uint32_t>(rhs.v);
+    const uint32_t t2 = t0 * t1;
+
+    const uint64_t t3 = static_cast<uint64_t>(t2) * static_cast<uint64_t>(R);
+    const uint32_t t4 = static_cast<uint32_t>(t3 >> 24);
+    const uint32_t t5 = t4 * static_cast<uint32_t>(Q);
+    const uint16_t t6 = static_cast<uint16_t>(t2 - t5);
+
+    const bool flg = t6 >= Q;
+    const uint16_t t7 = t6 - flg * Q;
+
+    this->v = t7;
   }
 
   // Computes canonical form of multiplicative inverse of prime field element,

--- a/include/kem_keygen.hpp
+++ b/include/kem_keygen.hpp
@@ -32,7 +32,7 @@ keygen(uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes public key
   constexpr size_t skoff1 = skoff0 + pklen;
   constexpr size_t skoff2 = skoff1 + 32;
 
-  random_data<uint8_t>(seckey + skoff2, zlen);    // random sample 32 -bytes z
+  kyber_utils::random_data<uint8_t>(seckey + skoff2, zlen); // sample 32 -bytes
   cpapke::keygen<k, eta1>(pubkey, seckey);        // CPAPKE key generation
   std::memcpy(seckey + skoff0, pubkey, pklen);    // copy public key
   sha3_256::hash(pubkey, pklen, seckey + skoff1); // hash public key

--- a/include/pke_keygen.hpp
+++ b/include/pke_keygen.hpp
@@ -31,7 +31,7 @@ keygen(uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes public key
 {
   // step 1
   uint8_t d[32]{};
-  random_data<uint8_t>(d, sizeof(d));
+  kyber_utils::random_data<uint8_t>(d, sizeof(d));
 
   // step 2
   uint8_t g_out[64]{};

--- a/include/pke_keygen.hpp
+++ b/include/pke_keygen.hpp
@@ -102,20 +102,11 @@ keygen(uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes public key
     N += 1;
   }
 
-  // step 17
-  ff::ff_t s_prime[k * ntt::N]{};
-
+  // step 17, 18
   for (size_t i = 0; i < k; i++) {
     const size_t off = i * ntt::N;
-    ntt::ntt(s + off, s_prime + off);
-  }
-
-  // step 18
-  ff::ff_t e_prime[k * ntt::N]{};
-
-  for (size_t i = 0; i < k; i++) {
-    const size_t off = i * ntt::N;
-    ntt::ntt(e + off, e_prime + off);
+    ntt::ntt(s + off);
+    ntt::ntt(e + off);
   }
 
   // step 19
@@ -132,7 +123,7 @@ keygen(uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes public key
       const size_t aoff = (i * k + j) * ntt::N;
       const size_t soff = j * ntt::N;
 
-      ntt::polymul(A_prime + aoff, s_prime + soff, tmp);
+      ntt::polymul(A_prime + aoff, s + soff, tmp);
 
       for (size_t l = 0; l < ntt::N; l++) {
         t_prime[toff + l] += tmp[l];
@@ -140,19 +131,17 @@ keygen(uint8_t* const __restrict pubkey, // (k * 12 * 32 + 32) -bytes public key
     }
 
     for (size_t l = 0; l < ntt::N; l++) {
-      t_prime[toff + l] += e_prime[eoff + l];
+      t_prime[toff + l] += e[eoff + l];
     }
   }
 
   // step 20, 21, 22
   for (size_t i = 0; i < k; i++) {
-    const size_t toff = i * ntt::N;
-    const size_t soff = i * ntt::N;
-    const size_t pkoff = i * 12 * 32;
-    const size_t skoff = i * 12 * 32;
+    const size_t off0 = i * ntt::N;
+    const size_t off1 = i * 12 * 32;
 
-    kyber_utils::encode<12>(t_prime + toff, pubkey + pkoff);
-    kyber_utils::encode<12>(s_prime + soff, seckey + skoff);
+    kyber_utils::encode<12>(t_prime + off0, pubkey + off1);
+    kyber_utils::encode<12>(s + off0, seckey + off1);
   }
 
   constexpr size_t pkoff = k * 12 * 32;

--- a/include/sampling.hpp
+++ b/include/sampling.hpp
@@ -35,15 +35,13 @@ parse(shake128::shake128* const __restrict hasher, // Squeezes arbitrary bytes
     const uint16_t d2 = (static_cast<uint16_t>(buf[1] >> 4) << 0) ^
                         (static_cast<uint16_t>(buf[2]) << 4);
 
-    if (d1 < q) {
-      poly[i] = ff::ff_t{ d1 };
-      i++;
-    }
+    const bool flg0 = d1 < q;
+    poly[i] = ff::ff_t{ static_cast<uint16_t>(d1 * flg0) };
+    i = i + 1 * flg0;
 
-    if ((d2 < q) && (i < n)) {
-      poly[i] = ff::ff_t{ d2 };
-      i++;
-    }
+    const bool flg1 = (d2 < q) & (i < n);
+    poly[i] = ff::ff_t{ static_cast<uint16_t>(d2 * flg1) };
+    i = i + 1 * flg1;
   }
 }
 

--- a/include/test_cpa_pke.hpp
+++ b/include/test_cpa_pke.hpp
@@ -40,8 +40,8 @@ test_kyber_cpa_pke()
   std::memset(enc, 0, enclen);
   std::memset(dec, 0, mlen);
 
-  random_data<uint8_t>(txt, mlen);
-  random_data<uint8_t>(rcoin, mlen);
+  kyber_utils::random_data<uint8_t>(txt, mlen);
+  kyber_utils::random_data<uint8_t>(rcoin, mlen);
 
   cpapke::keygen<k, eta1>(pkey, skey);
   cpapke::encrypt<k, eta1, eta2, du, dv>(pkey, txt, rcoin, enc);

--- a/include/test_ntt.hpp
+++ b/include/test_ntt.hpp
@@ -20,22 +20,22 @@ test_ntt_intt()
 
   ff::ff_t* poly_a = static_cast<ff::ff_t*>(std::malloc(poly_len));
   ff::ff_t* poly_b = static_cast<ff::ff_t*>(std::malloc(poly_len));
-  ff::ff_t* poly_c = static_cast<ff::ff_t*>(std::malloc(poly_len));
 
   for (size_t i = 0; i < ntt::N; i++) {
     poly_a[i] = ff::ff_t::random();
   }
 
-  ntt::ntt(poly_a, poly_b);
-  ntt::intt(poly_b, poly_c);
+  std::memcpy(poly_b, poly_a, poly_len);
+
+  ntt::ntt(poly_b);
+  ntt::intt(poly_b);
 
   for (size_t i = 0; i < ntt::N; i++) {
-    assert(poly_a[i] == poly_c[i]);
+    assert(poly_a[i] == poly_b[i]);
   }
 
   std::free(poly_a);
   std::free(poly_b);
-  std::free(poly_c);
 }
 
 }

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -6,6 +6,9 @@
 #include <sstream>
 #include <type_traits>
 
+// IND-CPA-secure Public Key Encryption Scheme Utilities
+namespace kyber_utils {
+
 // Generates N -many random values of type T | N >= 0
 template<typename T>
 static inline void
@@ -33,4 +36,6 @@ to_hex(const uint8_t* const bytes, const size_t len)
   }
 
   return ss.str();
+}
+
 }


### PR DESCRIPTION
- [x] Make (i)NTT implementation in-place -- avoiding unnecessary `memcpy`
- [x] Introduce compound subtraction and multiplication operators, when operating with `ff::ff_t` type

> Saving ~2 ns for subtraction and multiplication over Z_q

---

At commit dd47cb2419f1ca793b9fd57b284f1e1c97434297, on **Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz**

```bash
2022-09-28T13:12:33+04:00
Running ./bench/a.out
Run on (8 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB
  L1 Instruction 32 KiB
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB
Load Average: 2.08, 1.98, 1.91
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
bench_kyber::ff_add                            4.06 ns         4.05 ns    171697822
bench_kyber::ff_compound_add                   1.92 ns         1.92 ns    362560923
bench_kyber::ff_sub                            4.24 ns         4.23 ns    164150859
bench_kyber::ff_compound_sub                   2.10 ns         2.10 ns    333342857
bench_kyber::ff_neg                           0.828 ns        0.822 ns    854930506
bench_kyber::ff_mul                            6.74 ns         6.73 ns     97859669
bench_kyber::ff_compound_mul                   4.48 ns         4.47 ns    156239538
bench_kyber::ff_inv                            66.9 ns         66.9 ns      8785361
bench_kyber::ff_div                            76.1 ns         76.1 ns     11760051
bench_kyber::ff_exp                             410 ns          410 ns      1759156
bench_kyber::encode<1>                          148 ns          148 ns      4734560 bytes_per_second=206.057M/s
bench_kyber::decode<1>                          144 ns          144 ns      4870073 bytes_per_second=212.067M/s
bench_kyber::encode<4>                          927 ns          927 ns       738693 bytes_per_second=131.72M/s
bench_kyber::decode<4>                          900 ns          898 ns       777605 bytes_per_second=135.865M/s
bench_kyber::encode<5>                         1805 ns         1803 ns       390810 bytes_per_second=84.6427M/s
bench_kyber::decode<5>                         1653 ns         1651 ns       426892 bytes_per_second=92.4135M/s
bench_kyber::encode<10>                        2946 ns         2941 ns       238515 bytes_per_second=103.768M/s
bench_kyber::decode<10>                        3022 ns         3018 ns       233518 bytes_per_second=101.135M/s
bench_kyber::encode<11>                        4170 ns         4159 ns       168945 bytes_per_second=80.7085M/s
bench_kyber::decode<11>                        3870 ns         3866 ns       181117 bytes_per_second=86.8249M/s
bench_kyber::encode<12>                        3522 ns         3518 ns       198937 bytes_per_second=104.082M/s
bench_kyber::decode<12>                        3580 ns         3575 ns       197125 bytes_per_second=102.429M/s
bench_kyber::compress<1>                       5.23 ns         5.23 ns    130404814
bench_kyber::decompress<1>                     4.57 ns         4.57 ns    151764150
bench_kyber::compress<4>                       5.24 ns         5.24 ns    131467743
bench_kyber::decompress<4>                     4.84 ns         4.83 ns    143986112
bench_kyber::compress<5>                       5.23 ns         5.23 ns    131878897
bench_kyber::decompress<5>                     4.83 ns         4.82 ns    144529855
bench_kyber::compress<10>                      5.01 ns         5.00 ns    136681376
bench_kyber::decompress<10>                    4.83 ns         4.82 ns    145118925
bench_kyber::compress<11>                      5.07 ns         5.06 ns    138350858
bench_kyber::decompress<11>                    4.86 ns         4.86 ns    135054311
bench_kyber::ntt                               1615 ns         1592 ns       439329
bench_kyber::intt                              1508 ns         1497 ns       460608
bench_kyber::polymul                            367 ns          366 ns      1864211
bench_kyber::random_data<32>                  11618 ns        11459 ns        69520
bench_kyber::pke_keygen<2, 3>                 55224 ns        54716 ns        12662 items_per_second=18.2763k/s
bench_kyber::encrypt<2, 3, 2, 10, 4>          42178 ns        41758 ns        16641 items_per_second=23.9475k/s
bench_kyber::decrypt<2, 3, 2, 10, 4>          20202 ns        20113 ns        32982 items_per_second=49.7184k/s
bench_kyber::pke_keygen<3, 2>                 77117 ns        76626 ns         8946 items_per_second=13.0503k/s
bench_kyber::encrypt<3, 2, 2, 10, 4>          68981 ns        68248 ns        10120 items_per_second=14.6524k/s
bench_kyber::decrypt<3, 2, 2, 10, 4>          29876 ns        29624 ns        23459 items_per_second=33.7568k/s
bench_kyber::pke_keygen<4, 2>                131868 ns       128842 ns         6593 items_per_second=7.76145k/s
bench_kyber::encrypt<4, 2, 2, 11, 5>         118440 ns       114292 ns         6479 items_per_second=8.74952k/s
bench_kyber::decrypt<4, 2, 2, 11, 5>          42402 ns        42234 ns        15612 items_per_second=23.6774k/s
bench_kyber::kem_keygen<2, 3>                 63160 ns        63096 ns         9851 items_per_second=15.8488k/s
bench_kyber::encapsulate<2, 3, 2, 10, 4>      55426 ns        55368 ns        11332 items_per_second=18.061k/s
bench_kyber::decapsulate<2, 3, 2, 10, 4>      63287 ns        62948 ns        10263 items_per_second=15.8861k/s
bench_kyber::kem_keygen<3, 2>                 87242 ns        87143 ns         7413 items_per_second=11.4754k/s
bench_kyber::encapsulate<3, 2, 2, 10, 4>      82806 ns        82684 ns         8121 items_per_second=12.0942k/s
bench_kyber::decapsulate<3, 2, 2, 10, 4>      96234 ns        96157 ns         7160 items_per_second=10.3996k/s
bench_kyber::kem_keygen<4, 2>                120004 ns       119906 ns         5591 items_per_second=8.33987k/s
bench_kyber::encapsulate<4, 2, 2, 11, 5>     120743 ns       120661 ns         5266 items_per_second=8.28768k/s
bench_kyber::decapsulate<4, 2, 2, 11, 5>     148354 ns       148129 ns         4706 items_per_second=6.75087k/s
```