### PR TITLE
Make Key Decapsulation Constant-Time

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "sha3"]
 	path = sha3
 	url = https://github.com/itzmeanjan/sha3.git
+[submodule "subtle"]
+	path = subtle
+	url = https://github.com/itzmeanjan/subtle.git

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,16 @@ CXX = g++
 CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
 OPTFLAGS = -O3 -march=native -mtune=native
 IFLAGS = -I ./include
-DEP_IFLAGS = -I ./sha3/include
+DEP_IFLAGS = -I ./sha3/include -I ./subtle/include
 
 all: testing test_kat
 
-wrapper/libkyber_kem.so: wrapper/kyber_kem.cpp include/*.hpp sha3/include/*.hpp
+wrapper/libkyber_kem.so: wrapper/kyber_kem.cpp include/*.hpp sha3/include/*.hpp subtle/include/*.hpp
 	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DEP_IFLAGS) -fPIC --shared $< -o $@
 
 lib: wrapper/libkyber_kem.so
 
-test/a.out: test/main.cpp include/*.hpp sha3/include/*.hpp include/test/*.hpp
+test/a.out: test/main.cpp include/*.hpp include/test/*.hpp sha3/include/*.hpp subtle/include/*.hpp
 	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DEP_IFLAGS) $< -o $@
 
 testing: test/a.out
@@ -26,7 +26,7 @@ clean:
 format:
 	find . -path ./sha3 -prune -name '*.hpp' -o -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla && python3 -m black wrapper/python/*.py
 
-bench/a.out: bench/main.cpp include/*.hpp sha3/include/*.hpp include/bench/*.hpp
+bench/a.out: bench/main.cpp include/*.hpp include/bench/*.hpp sha3/include/*.hpp subtle/include/*.hpp
 	# make sure you've google-benchmark globally installed;
 	# see https://github.com/google/benchmark/tree/3b19d722#installation
 	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DEP_IFLAGS) $< -lbenchmark -o $@

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Warning** **This implementation is not yet audited. If you consider using it in production, be careful !**
+> **Warning** **This Kyber implementation is conformant with Kyber [specification](https://pq-crystals.org/kyber/data/kyber-specification-round3-20210804.pdf) and I also *try* to make it constant-time but be informed that it is not yet audited. If you consider using it in production, be careful !**
 
 # kyber
 CRYSTALS-Kyber: Post-Quantum Public-key Encryption &amp; Key-establishment Algorithm
@@ -40,11 +40,10 @@ Decapsulation | Secret Key and Cipher Text | SHAKE256 KDF
 
 Here I'm developing & maintaining `kyber` - a zero-dependency, header-only and easy-to-use C++ library implementing Kyber PKE and KEM, supporting Kyber-{512, 768, 1024} parameter sets, as defined in table 1 of Kyber specification. 
 
-Only dependency is `sha3`, which itself is a zero-dependency, header-only C++ library that I decided to write to modularize a common PQC dependency i.e. SHA3 hash functions and extendable output functions are fairly common symmetric key primitives used in post-quantum cryptographic constructions such as Kyber, Dilithium, Falcon and SPHINCS+ etc..
+Only dependency is `sha3` and `subtle` - both of them are zero-dependency, header-only C++ libraries themselves. I decided to write `sha3` so that I can modularize a fairly common PQC dependency because SHA3 hash functions and extendable output functions are pretty common symmetric key primitives used in post-quantum cryptographic constructions such as Kyber, Dilithium, Falcon and SPHINCS+ etc.. While `subtle` is a pretty light-weight library which helps achieving constant-timeness in cryptographic libraries. Here it's used for performing constant-time byte comparison and conditional selection without using booleans - only relying on integer addition, subtration and bit-wise operations.
 
-- `sha3` is pinned to specific commit, using git submodule, in `kyber`
+- Both `sha3` and `subtle` are pinned to specific commit, using git submodule.
 - See [usage](#usage) section below for git submodule set up guide.
-- Find more about `sha3` [here](https://github.com/itzmeanjan/sha3.git)
 
 > **Note**
 
@@ -94,7 +93,7 @@ $ python3 -m pip install -r wrapper/python/requirements.txt --user
 
 - For benchmarking Kyber implementation on CPU systems, you'll need to have `google-benchmark` header and library globally installed. You may want to follow [this](https://github.com/google/benchmark/tree/3b19d722#installation) guide.
 
-- For importing `sha3` dependency, initialize & update git submodule after cloning this repository
+- For importing `sha3` and `subtle`, initialize & update git submodule after cloning this repository
 
 ```bash
 git clone https://github.com/itzmeanjan/kyber.git
@@ -159,7 +158,7 @@ cd
 git clone https://github.com/itzmeanjan/kyber.git
 ```
 
-- Initialize and update git submodule, so that `sha3` dependency is available inside `kyber` source tree
+- Initialize and update git submodule, so that `sha3` and `subtle` are available inside `kyber` source tree
 
 ```bash
 cd kyber

--- a/bench/README.md
+++ b/bench/README.md
@@ -13,7 +13,7 @@ make benchmark
 ### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz ( compiled with Clang )
 
 ```bash
-2023-02-27T13:09:55+04:00
+2023-03-02T16:48:19+04:00
 Running ./bench/a.out
 Run on (8 X 2400 MHz CPU s)
 CPU Caches:
@@ -21,34 +21,34 @@ CPU Caches:
   L1 Instruction 32 KiB
   L2 Unified 256 KiB (x4)
   L3 Unified 6144 KiB
-Load Average: 1.76, 1.95, 1.91
+Load Average: 1.38, 1.52, 1.58
 ----------------------------------------------------------------
 Benchmark                      Time             CPU   Iterations
 ----------------------------------------------------------------
-kyber512_pke_keygen         18.2 us         18.2 us        38533
-kyber512_pke_encrypt        20.0 us         20.0 us        34027
-kyber512_pke_decrypt        5.80 us         5.77 us       117661
-kyber768_pke_keygen         31.2 us         31.2 us        22671
-kyber768_pke_encrypt        33.6 us         33.6 us        20787
-kyber768_pke_decrypt        7.67 us         7.66 us        88869
-kyber1024_pke_keygen        48.8 us         48.7 us        13735
-kyber1024_pke_encrypt       50.9 us         50.8 us        13175
-kyber1024_pke_decrypt       10.1 us         10.1 us        64465
-kyber512_kem_keygen         20.3 us         20.2 us        34569
-kyber512_kem_encap          25.1 us         25.1 us        27921
-kyber512_kem_decap          28.5 us         28.4 us        24889
-kyber768_kem_keygen         34.2 us         34.2 us        20850
-kyber768_kem_encap          40.5 us         40.4 us        17326
-kyber768_kem_decap          45.4 us         45.3 us        15534
-kyber1024_kem_keygen        53.4 us         53.4 us        12770
-kyber1024_kem_encap         60.2 us         60.1 us        10952
-kyber1024_kem_decap         66.1 us         66.0 us        10224
+kyber512_pke_keygen         18.3 us         18.3 us        37845
+kyber512_pke_encrypt        20.1 us         20.0 us        34266
+kyber512_pke_decrypt        5.69 us         5.68 us       119746
+kyber768_pke_keygen         31.0 us         31.0 us        22730
+kyber768_pke_encrypt        34.1 us         34.0 us        20695
+kyber768_pke_decrypt        7.74 us         7.73 us        84223
+kyber1024_pke_keygen        48.8 us         48.8 us        13922
+kyber1024_pke_encrypt       51.7 us         51.6 us        13456
+kyber1024_pke_decrypt       10.1 us         10.1 us        68305
+kyber512_kem_keygen         20.3 us         20.3 us        34056
+kyber512_kem_encap          25.2 us         25.2 us        27670
+kyber512_kem_decap          28.5 us         28.5 us        24088
+kyber768_kem_keygen         33.9 us         33.9 us        20609
+kyber768_kem_encap          40.8 us         40.7 us        17166
+kyber768_kem_decap          45.2 us         45.2 us        15309
+kyber1024_kem_keygen        53.6 us         53.5 us        12094
+kyber1024_kem_encap         60.9 us         60.8 us        11317
+kyber1024_kem_decap         68.2 us         68.1 us        10102
 ```
 
 ### On Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz ( compiled with GCC )
 
 ```bash
-2023-02-27T09:13:34+00:00
+2023-03-02T12:45:32+00:00
 Running ./bench/a.out
 Run on (4 X 2300.08 MHz CPU s)
 CPU Caches:
@@ -56,34 +56,34 @@ CPU Caches:
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
   L3 Unified 46080 KiB (x1)
-Load Average: 0.27, 0.19, 0.10
+Load Average: 0.08, 0.02, 0.01
 ----------------------------------------------------------------
 Benchmark                      Time             CPU   Iterations
 ----------------------------------------------------------------
-kyber512_pke_keygen         35.0 us         35.0 us        20045
-kyber512_pke_encrypt        44.6 us         44.6 us        15677
-kyber512_pke_decrypt        13.9 us         13.9 us        50370
-kyber768_pke_keygen         59.1 us         59.1 us        11830
-kyber768_pke_encrypt        73.0 us         73.0 us         9577
-kyber768_pke_decrypt        18.4 us         18.4 us        37957
-kyber1024_pke_keygen        92.8 us         92.8 us         7554
-kyber1024_pke_encrypt        110 us          110 us         6340
-kyber1024_pke_decrypt       22.6 us         22.6 us        30997
-kyber512_kem_keygen         38.7 us         38.7 us        18054
-kyber512_kem_encap          55.0 us         55.0 us        12745
-kyber512_kem_decap          65.0 us         65.0 us        10775
-kyber768_kem_keygen         64.6 us         64.6 us        10849
-kyber768_kem_encap          86.7 us         86.7 us         8099
-kyber768_kem_decap          99.7 us         99.7 us         7024
-kyber1024_kem_keygen         101 us          101 us         6962
-kyber1024_kem_encap          128 us          128 us         5447
-kyber1024_kem_decap          144 us          144 us         4874
+kyber512_pke_keygen         34.9 us         34.9 us        20044
+kyber512_pke_encrypt        45.4 us         45.4 us        15373
+kyber512_pke_decrypt        13.9 us         13.9 us        50228
+kyber768_pke_keygen         59.0 us         59.0 us        11860
+kyber768_pke_encrypt        72.2 us         72.2 us         9695
+kyber768_pke_decrypt        18.2 us         18.2 us        38453
+kyber1024_pke_keygen        92.5 us         92.5 us         7576
+kyber1024_pke_encrypt        109 us          109 us         6406
+kyber1024_pke_decrypt       22.9 us         22.9 us        30623
+kyber512_kem_keygen         38.8 us         38.8 us        18040
+kyber512_kem_encap          55.1 us         55.1 us        12683
+kyber512_kem_decap          64.7 us         64.7 us        10818
+kyber768_kem_keygen         64.5 us         64.5 us        10827
+kyber768_kem_encap          85.8 us         85.8 us         8148
+kyber768_kem_decap          99.5 us         99.5 us         7027
+kyber1024_kem_keygen         101 us          101 us         6949
+kyber1024_kem_encap          127 us          127 us         5513
+kyber1024_kem_decap          142 us          142 us         4886
 ```
 
 ### On Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz ( compiled with Clang )
 
 ```bash
-2023-02-27T09:14:34+00:00
+2023-03-02T12:46:40+00:00
 Running ./bench/a.out
 Run on (4 X 2300.08 MHz CPU s)
 CPU Caches:
@@ -91,26 +91,26 @@ CPU Caches:
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
   L3 Unified 46080 KiB (x1)
-Load Average: 0.40, 0.24, 0.12
+Load Average: 0.30, 0.10, 0.03
 ----------------------------------------------------------------
 Benchmark                      Time             CPU   Iterations
 ----------------------------------------------------------------
-kyber512_pke_keygen         29.5 us         29.5 us        23719
-kyber512_pke_encrypt        31.7 us         31.7 us        22010
-kyber512_pke_decrypt        9.77 us         9.77 us        71689
-kyber768_pke_keygen         49.2 us         49.2 us        14226
-kyber768_pke_encrypt        53.1 us         53.1 us        13149
-kyber768_pke_decrypt        13.3 us         13.3 us        52825
-kyber1024_pke_keygen        77.5 us         77.5 us         9023
-kyber1024_pke_encrypt       82.3 us         82.3 us         8557
-kyber1024_pke_decrypt       16.6 us         16.6 us        42071
-kyber512_kem_keygen         32.7 us         32.7 us        21392
-kyber512_kem_encap          39.7 us         39.7 us        17620
-kyber512_kem_decap          45.9 us         45.9 us        15237
-kyber768_kem_keygen         54.0 us         54.0 us        12974
-kyber768_kem_encap          65.0 us         65.0 us        10873
-kyber768_kem_decap          72.6 us         72.5 us         9656
-kyber1024_kem_keygen        83.9 us         83.9 us         8346
-kyber1024_kem_encap         96.2 us         96.2 us         7276
-kyber1024_kem_decap          107 us          107 us         6565
+kyber512_pke_keygen         29.6 us         29.6 us        23664
+kyber512_pke_encrypt        32.0 us         32.0 us        21853
+kyber512_pke_decrypt        9.77 us         9.77 us        71624
+kyber768_pke_keygen         49.7 us         49.7 us        14087
+kyber768_pke_encrypt        53.5 us         53.5 us        13091
+kyber768_pke_decrypt        13.2 us         13.2 us        53000
+kyber1024_pke_keygen        77.7 us         77.7 us         9007
+kyber1024_pke_encrypt       82.7 us         82.7 us         8508
+kyber1024_pke_decrypt       16.8 us         16.8 us        41724
+kyber512_kem_keygen         32.8 us         32.8 us        21330
+kyber512_kem_encap          40.0 us         40.0 us        17439
+kyber512_kem_decap          46.1 us         46.1 us        15174
+kyber768_kem_keygen         54.7 us         54.7 us        12834
+kyber768_kem_encap          64.4 us         64.4 us        10874
+kyber768_kem_decap          72.8 us         72.8 us         9611
+kyber1024_kem_keygen        83.8 us         83.8 us         8322
+kyber1024_kem_encap         96.0 us         96.0 us         7279
+kyber1024_kem_decap          106 us          106 us         6602
 ```


### PR DESCRIPTION
Using `subtle` ( more @ https://github.com/itzmeanjan/subtle ) for 

- comparing ( i.e. byte comparison ) provided cipher text and computed cipher text, in decapsulation routine.
- selecting which seed ( actually first 32 -bytes ) to use with resulting KDF, based on result of comparison.

This should make decapsulation routine constant-time, making it ~1% more expensive, in terms of CPU time. 

<img width="996" alt="image" src="https://user-images.githubusercontent.com/45074836/222442378-35bd98a3-0ce4-44fa-a3ba-91648cb6d759.png">
